### PR TITLE
Scrolling/Spacing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html style="overflow: auto;">
   <head>
 
     <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet">

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-  <v-stepper v-model="e1" style="overflow: scroll; min-height: calc(100% - 48px);">
+  <v-stepper v-model="e1" style="overflow: auto; min-height: calc(100% - 48px);">
     <v-stepper-header>
       <v-stepper-step 
       v-for="(step, index) in steps"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-  <v-stepper v-model="e1" style="overflow: auto; min-height: calc(100% - 48px);">
+  <v-stepper v-model="e1" style="overflow: auto; height: calc(100% - 48px);">
     <v-stepper-header>
       <v-stepper-step 
       v-for="(step, index) in steps"


### PR DESCRIPTION
sets overflow to auto for the sites' html tag as well as the stepper so that scroll bars only appear when necessary. Also changed ```min-height``` to ```height``` so that the calendar step doesn't overlap the previous button. 