### PR TITLE
🚑 `POST /applet`: `400`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,151 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+- Links to latest released version in previous versions.
+- "Why keep a changelog?" section.
+- "Who needs a changelog?" section.
+- "How do I make a changelog?" section.
+- "Frequently Asked Questions" section.
+- New "Guiding Principles" sub-section to "How do I make a changelog?".
+- Simplified and Traditional Chinese translations from [@tianshuo](https://github.com/tianshuo).
+- German translation from [@mpbzh](https://github.com/mpbzh) & [@Art4](https://github.com/Art4).
+- Italian translation from [@azkidenz](https://github.com/azkidenz).
+- Swedish translation from [@magol](https://github.com/magol).
+- Turkish translation from [@karalamalar](https://github.com/karalamalar).
+- French translation from [@zapashcanon](https://github.com/zapashcanon).
+- Brazilian Portugese translation from [@Webysther](https://github.com/Webysther).
+- Polish translation from [@amielucha](https://github.com/amielucha) & [@m-aciek](https://github.com/m-aciek).
+- Russian translation from [@aishek](https://github.com/aishek).
+- Czech translation from [@h4vry](https://github.com/h4vry).
+- Slovak translation from [@jkostolansky](https://github.com/jkostolansky).
+- Korean translation from [@pierceh89](https://github.com/pierceh89).
+- Croatian translation from [@porx](https://github.com/porx).
+- Persian translation from [@Hameds](https://github.com/Hameds).
+- Ukrainian translation from [@osadchyi-s](https://github.com/osadchyi-s).
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+- Start versioning based on the current English version at 0.3.0 to help
+translation authors keep things up-to-date.
+- Rewrite "What makes unicorns cry?" section.
+- Rewrite "Ignoring Deprecations" sub-section to clarify the ideal
+  scenario.
+- Improve "Commit log diffs" sub-section to further argument against
+  them.
+- Merge "Why can’t people just use a git log diff?" with "Commit log
+  diffs"
+- Fix typos in Simplified Chinese and Traditional Chinese translations.
+- Fix typos in Brazilian Portuguese translation.
+- Fix typos in Turkish translation.
+- Fix typos in Czech translation.
+- Fix typos in Swedish translation.
+- Improve phrasing in French translation.
+- Fix phrasing and spelling in German translation.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).
+- pt-BR translation from [@tallesl](https://github.com/tallesl).
+- es-ES translation from [@ZeliosAriex](https://github.com/ZeliosAriex).
+
+## [0.2.0] - 2015-10-06
+### Changed
+- Remove exclusionary mentions of "open source" since this project can
+benefit both "open" and "closed" source projects equally.
+
+## [0.1.0] - 2015-10-06
+### Added
+- Answer "Should you ever rewrite a change log?".
+
+### Changed
+- Improve argument against commit logs.
+- Start following [SemVer](https://semver.org) properly.
+
+## [0.0.8] - 2015-02-17
+### Changed
+- Update year to match in every README example.
+- Reluctantly stop making fun of Brits only, since most of the world
+  writes dates in a strange way.
+
+### Fixed
+- Fix typos in recent README changes.
+- Update outdated unreleased diff link.
+
+## [0.0.7] - 2015-02-16
+### Added
+- Link, and make it obvious that date format is ISO 8601.
+
+### Changed
+- Clarified the section on "Is there a standard change log format?".
+
+### Fixed
+- Fix Markdown links to tag comparison URL with footnote-style links.
+
+## [0.0.6] - 2014-12-12
+### Added
+- README section on "yanked" releases.
+
+## [0.0.5] - 2014-08-09
+### Added
+- Markdown links to version tags on release headings.
+- Unreleased section to gather unreleased changes and encourage note
+keeping prior to releases.
+
+## [0.0.4] - 2014-08-09
+### Added
+- Better explanation of the difference between the file ("CHANGELOG")
+and its function "the change log".
+
+### Changed
+- Refer to a "change log" instead of a "CHANGELOG" throughout the site
+to differentiate between the file and the purpose of the file — the
+logging of changes.
+
+### Removed
+- Remove empty sections from CHANGELOG, they occupy too much space and
+create too much noise in the file. People will have to assume that the
+missing sections were intentionally left out because they contained no
+notable changes.
+
+## [0.0.3] - 2014-08-09
+### Added
+- "Why should I care?" section mentioning The Changelog podcast.
+
+## [0.0.2] - 2014-07-10
+### Added
+- Explanation of the recommended reverse chronological release ordering.
+
+## [0.0.1] - 2014-05-31
+### Added
+- This CHANGELOG file to hopefully serve as an evolving example of a
+  standardized open source project CHANGELOG.
+- CNAME file to enable GitHub Pages custom domain
+- README now contains answers to common questions about CHANGELOGs
+- Good examples and basic guidelines, including proper date formatting.
+- Counter-examples: "What makes unicorns cry?"
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v1.0.0
+[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
+[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
+[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - :construction: Draft
 
 [Unreleased]: https://github.com/ChildMindInstitute/mindlogger-admin/compare/v0.1.1...HEAD
-[0.1.1]: https://github.com/ChildMindInstitute/mindlogger-admin/compare/v0.1.0...v1.0.0
+[0.1.1]: https://github.com/ChildMindInstitute/mindlogger-admin/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ChildMindInstitute/mindlogger-admin/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,146 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2017-06-20
+## [0.1.1] - 2019-11-06
 ### Added
-- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
-- Version navigation.
-- Links to latest released version in previous versions.
-- "Why keep a changelog?" section.
-- "Who needs a changelog?" section.
-- "How do I make a changelog?" section.
-- "Frequently Asked Questions" section.
-- New "Guiding Principles" sub-section to "How do I make a changelog?".
-- Simplified and Traditional Chinese translations from [@tianshuo](https://github.com/tianshuo).
-- German translation from [@mpbzh](https://github.com/mpbzh) & [@Art4](https://github.com/Art4).
-- Italian translation from [@azkidenz](https://github.com/azkidenz).
-- Swedish translation from [@magol](https://github.com/magol).
-- Turkish translation from [@karalamalar](https://github.com/karalamalar).
-- French translation from [@zapashcanon](https://github.com/zapashcanon).
-- Brazilian Portugese translation from [@Webysther](https://github.com/Webysther).
-- Polish translation from [@amielucha](https://github.com/amielucha) & [@m-aciek](https://github.com/m-aciek).
-- Russian translation from [@aishek](https://github.com/aishek).
-- Czech translation from [@h4vry](https://github.com/h4vry).
-- Slovak translation from [@jkostolansky](https://github.com/jkostolansky).
-- Korean translation from [@pierceh89](https://github.com/pierceh89).
-- Croatian translation from [@porx](https://github.com/porx).
-- Persian translation from [@Hameds](https://github.com/Hameds).
-- Ukrainian translation from [@osadchyi-s](https://github.com/osadchyi-s).
+- :newspaper: CHANGELOG
 
 ### Changed
-- Start using "changelog" over "change log" since it's the common usage.
-- Start versioning based on the current English version at 0.3.0 to help
-translation authors keep things up-to-date.
-- Rewrite "What makes unicorns cry?" section.
-- Rewrite "Ignoring Deprecations" sub-section to clarify the ideal
-  scenario.
-- Improve "Commit log diffs" sub-section to further argument against
-  them.
-- Merge "Why can’t people just use a git log diff?" with "Commit log
-  diffs"
-- Fix typos in Simplified Chinese and Traditional Chinese translations.
-- Fix typos in Brazilian Portuguese translation.
-- Fix typos in Turkish translation.
-- Fix typos in Czech translation.
-- Fix typos in Swedish translation.
-- Improve phrasing in French translation.
-- Fix phrasing and spelling in German translation.
+- :ambulance: :arrow_up: :tractor: :hammer: :art: Renamed `activitySet` to `protocol` to accommodate [upstream changes in **reproschema**](https://github.com/ReproNim/reproschema/pull/277)
+- :tractor: Renamed package from "dayspan-vuetify-example" to "mindlogger-admin"
 
-### Removed
-- Section about "changelog" vs "CHANGELOG".
+## [0.1.0] - 2019-05-22 ‒ 10-31
+- :construction: Draft
 
-## [0.3.0] - 2015-12-03
-### Added
-- RU translation from [@aishek](https://github.com/aishek).
-- pt-BR translation from [@tallesl](https://github.com/tallesl).
-- es-ES translation from [@ZeliosAriex](https://github.com/ZeliosAriex).
-
-## [0.2.0] - 2015-10-06
-### Changed
-- Remove exclusionary mentions of "open source" since this project can
-benefit both "open" and "closed" source projects equally.
-
-## [0.1.0] - 2015-10-06
-### Added
-- Answer "Should you ever rewrite a change log?".
-
-### Changed
-- Improve argument against commit logs.
-- Start following [SemVer](https://semver.org) properly.
-
-## [0.0.8] - 2015-02-17
-### Changed
-- Update year to match in every README example.
-- Reluctantly stop making fun of Brits only, since most of the world
-  writes dates in a strange way.
-
-### Fixed
-- Fix typos in recent README changes.
-- Update outdated unreleased diff link.
-
-## [0.0.7] - 2015-02-16
-### Added
-- Link, and make it obvious that date format is ISO 8601.
-
-### Changed
-- Clarified the section on "Is there a standard change log format?".
-
-### Fixed
-- Fix Markdown links to tag comparison URL with footnote-style links.
-
-## [0.0.6] - 2014-12-12
-### Added
-- README section on "yanked" releases.
-
-## [0.0.5] - 2014-08-09
-### Added
-- Markdown links to version tags on release headings.
-- Unreleased section to gather unreleased changes and encourage note
-keeping prior to releases.
-
-## [0.0.4] - 2014-08-09
-### Added
-- Better explanation of the difference between the file ("CHANGELOG")
-and its function "the change log".
-
-### Changed
-- Refer to a "change log" instead of a "CHANGELOG" throughout the site
-to differentiate between the file and the purpose of the file — the
-logging of changes.
-
-### Removed
-- Remove empty sections from CHANGELOG, they occupy too much space and
-create too much noise in the file. People will have to assume that the
-missing sections were intentionally left out because they contained no
-notable changes.
-
-## [0.0.3] - 2014-08-09
-### Added
-- "Why should I care?" section mentioning The Changelog podcast.
-
-## [0.0.2] - 2014-07-10
-### Added
-- Explanation of the recommended reverse chronological release ordering.
-
-## [0.0.1] - 2014-05-31
-### Added
-- This CHANGELOG file to hopefully serve as an evolving example of a
-  standardized open source project CHANGELOG.
-- CNAME file to enable GitHub Pages custom domain
-- README now contains answers to common questions about CHANGELOGs
-- Good examples and basic guidelines, including proper date formatting.
-- Counter-examples: "What makes unicorns cry?"
-
-[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v1.0.0
-[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
-[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
-[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
-[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6
-[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5
-[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
-[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
-[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2
-[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.0.1
+[Unreleased]: https://github.com/ChildMindInstitute/mindlogger-admin/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/ChildMindInstitute/mindlogger-admin/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/ChildMindInstitute/mindlogger-admin/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "dayspan-vuetify-example",
-  "version": "0.1.0",
+  "name": "mindlogger-admin",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "dayspan-vuetify-example",
-  "version": "0.1.0",
+  "name": "mindlogger-admin",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/Components/Applets/AllApplets.vue
+++ b/src/Components/Applets/AllApplets.vue
@@ -42,12 +42,12 @@
         <v-card-text>
           <h3>Create a new applet:</h3>
           <v-text-field
-            v-model="newActivitySetURL"
+            v-model="newProtocolURL"
             label="activity set url"
           />
           <v-btn
             color="primary"
-            :disabled="!newActivitySetURL"
+            :disabled="!newProtocolURL"
             @click="onClickAdd"
           >
             Add
@@ -60,10 +60,10 @@
             and you will be able to create your own.
           </p>
           <p
-            v-for="activityInfo in sampleActivitySets"
+            v-for="activityInfo in sampleProtocols"
             :key="activityInfo.name"
           >
-            <a @click="newActivitySetURL=activityInfo.url">{{ activityInfo.name }}</a>
+            <a @click="newProtocolURL=activityInfo.url">{{ activityInfo.name }}</a>
           </p>
         </v-card-text>
       </v-card>
@@ -89,14 +89,14 @@ export default {
     }
   },
   data: () => ({
-    sampleActivitySets: config.activitySets,
+    sampleProtocols: config.protocols,
     dialog: false,
     /**
      * placeholder for the new applet URL
      * this will likely be a github link to an activity set
      * from the ReproNim
      */
-    newActivitySetURL: '',
+    newProtocolURL: '',
   }),
   computed: {
 
@@ -119,11 +119,11 @@ export default {
      */
     addNewApplet() {
       api.addNewApplet({
-        activitySetUrl: this.newActivitySetURL,
+        protocolUrl: this.newProtocolURL,
         token: this.$store.state.auth.authToken.token,
         apiHost: this.$store.state.backend,
       }).then(() => {
-        this.newActivitySetURL = '';
+        this.newProtocolURL = '';
         this.$emit('refreshAppletList');
       });
     },

--- a/src/Components/Utils/api/api.vue
+++ b/src/Components/Utils/api/api.vue
@@ -28,14 +28,14 @@ const setSchedule = ({ apiHost, token, id, data }) => axios({
   data,
 });
 
-const addNewApplet = ({ apiHost, token, activitySetUrl }) => axios({
+const addNewApplet = ({ apiHost, token, protocolUrl }) => axios({
 method: 'POST',
   url: `${apiHost}/applet/`,
   headers: {
     'Girder-Token': token,
   },
   params: {
-    activitySetUrl,
+    protocolUrl,
   },
 })
 

--- a/src/State/state.js
+++ b/src/State/state.js
@@ -21,13 +21,13 @@ const mutations = {
     }
     state.backend = backend;
   },
-  setCurrentApplet(state, activitySet) {
-    if (activitySet) {
-      state.currentApplet = activitySet;
+  setCurrentApplet(state, protocol) {
+    if (protocol) {
+      state.currentApplet = protocol;
     }
   },
-  setAllApplets(state, activitySets) {
-    state.allApplets = activitySets;
+  setAllApplets(state, protocols) {
+    state.allApplets = protocols;
   },
   setAuth(state, auth) {
     state.auth = auth;

--- a/src/Steps/SetApplet.vue
+++ b/src/Steps/SetApplet.vue
@@ -33,7 +33,7 @@ export default {
     Loading,
   },
   data: () => ({
-    sampleActivitySets: config.activitySets,
+    sampleProtocols: config.protocols,
     /**
      * placeholder for any error messages from axios
      */

--- a/src/config.js
+++ b/src/config.js
@@ -1,16 +1,16 @@
 export default {
-  activitySets: [
+  protocols: [
     {
       name: 'MindLogger Demo',
-      url: 'http://repronim.org/schema-standardization/activity-sets/mindlogger-demo/mindlogger-demo_schema',
+      url: 'http://repronim.org/schema-standardization/protocols/mindlogger-demo/mindlogger-demo_schema',
     },
     {
       name: 'Healthy Brain Network EMA',
-      url: 'http://repronim.org/schema-standardization/activity-sets/ema-hbn/ema-hbn_schema',
+      url: 'http://repronim.org/schema-standardization/protocols/ema-hbn/ema-hbn_schema',
     },
     {
       name: 'Cognitive Tasks',
-      url: 'http://repronim.org/schema-standardization/activity-sets/cognitive-tasks/cognitive-tasks_schema'
+      url: 'http://repronim.org/schema-standardization/protocols/cognitive-tasks/cognitive-tasks_schema'
     }
 
   ]


### PR DESCRIPTION
I missed handling a legacy `activitySet` key in the call for `POST /applet`. I _think_ this repo is the only application actively using that call, so instead of handling the legacy key, I'm updating to the current key here.

Resolves https://github.com/ChildMindInstitute/MindLogger-bug-reports/issues/40

https://github.com/ChildMindInstitute/MindLogger-bug-reports/issues/32 might happen when you add an applet until we re-resolve https://github.com/ChildMindInstitute/MindLogger-bug-reports/issues/35:

> The way [ChildMindInstitute/mindlogger-app-backend#211](https://github.com/ChildMindInstitute/mindlogger-app-backend/pull/211) handles legacy data makes this an issue again.

― https://github.com/ChildMindInstitute/MindLogger-bug-reports/issues/35#issuecomment-550409924