### PR TITLE
:ambulance: Save schedule

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -50,6 +50,14 @@
           >
             Continue
           </v-btn>
+          <v-btn
+            v-else
+            color="primary"
+            :disabled="!readyToContinue"
+            @click="save"
+          >
+            Save
+          </v-btn>
         </v-flex>
       </v-flex>
     </v-layout>
@@ -143,7 +151,7 @@ export default {
       {
         name: 'schedule',
         component: SetSchedule,
-      },
+      }
       // {
       //   name: 'reviewers',
       //   component: SetReviewers,
@@ -187,6 +195,9 @@ export default {
     next() {
       this.currentComponent.continueAction();
       this.e1 += 1;
+    },
+    save() {
+      this.currentComponent.continueAction();
     }
   }
 }

--- a/src/Steps/SetSchedule.vue
+++ b/src/Steps/SetSchedule.vue
@@ -80,12 +80,12 @@ export default {
     continueAction() {
       const scheduleForm = new FormData();
       if (this.currentApplet) {
-        if (this.currentApplet.schedule) {
+        if (this.currentApplet.applet.schedule) {
           // eslint-disable-next-line
           console.log('saving the schedule');
           const schedule = this.currentApplet.applet.schedule;
           scheduleForm.set('schedule', JSON.stringify(schedule || {}));
-          adminApi.setSchedule({
+          api.setSchedule({
             apiHost: this.$store.state.backend,
             id: this.currentApplet.applet._id,
             token: this.$store.state.auth.authToken.token,


### PR DESCRIPTION
Previously was only saving on continue, which was never hitting since the schedule tab got moved to the end. Still kind of gross because the "save" buttons on the modal cards only save to cache, but the save at the bottom should send to the db now.

Ref https://github.com/ChildMindInstitute/mindlogger-app-backend/issues/218