### PR TITLE
Squash Schedule Bug

### DIFF
--- a/src/Steps/SetSchedule.vue
+++ b/src/Steps/SetSchedule.vue
@@ -79,8 +79,7 @@ export default {
      */
     continueAction() {
       const scheduleForm = new FormData();
-      if (this.currentApplet) {
-        if (this.currentApplet.applet.schedule) {
+      if (this.currentApplet && this.currentApplet.applet && this.currentApplet.applet.schedule) {
           // eslint-disable-next-line
           console.log('saving the schedule');
           const schedule = this.currentApplet.applet.schedule;
@@ -93,9 +92,6 @@ export default {
           }).then(() => {
           });
         }
-
-      }
-
     },
   }
 }


### PR DESCRIPTION
Fixes the ```TypeError: Cannot read property 'schedule' of undefined``` error that was caused when ```this.currentApplet``` was defined but ```this.currentApplet.applet.schedule``` was not.