### PR TITLE
Builder to '/build' Route

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-    <router-view/>
+    <router-view />
   </v-app>
 </template>
 

--- a/src/Components/Applets/AllApplets.vue
+++ b/src/Components/Applets/AllApplets.vue
@@ -77,7 +77,7 @@
             <v-btn
               color="primary"
             >
-              Launch Builder (beta)
+              Launch Builder
             </v-btn>
           </router-link>
         </v-card-text>

--- a/src/Components/Applets/AllApplets.vue
+++ b/src/Components/Applets/AllApplets.vue
@@ -39,7 +39,7 @@
       v-model="dialog"
       max-width="800"
     >
-      <v-card v-if="!builderOpen">
+      <v-card>
         <v-card-text>
           <h3>Upload an activity set</h3>
           <v-text-field
@@ -70,16 +70,17 @@
           <p>
             Build a new activity set from scratch and download the schema files. Currently, this feature only supports radio items and text items.
           </p>
-          <v-btn
-            color="primary"
-            @click="builderOpen = true"
+          <router-link
+            to="/build"
+            target="_blank"
           >
-            Launch Builder (beta)
-          </v-btn>
+            <v-btn
+              color="primary"
+            >
+              Launch Builder (beta)
+            </v-btn>
+          </router-link>
         </v-card-text>
-      </v-card>
-      <v-card v-else>
-        <ActivitySetBuilder @closeBuilder="builderOpen = false" />
       </v-card>
     </v-dialog>
   </div>
@@ -87,7 +88,6 @@
 
 <script>
 import Applet from './Applet';
-import Components from 'activity-set-builder';
 import api from '../Utils/api/api.vue';
 import config from '../../config';
 
@@ -95,7 +95,6 @@ export default {
   name: 'AllApplets',
   components: {
     Applet,
-    ...Components
   },
   props: {
     applets: {
@@ -106,7 +105,6 @@ export default {
   data: () => ({
     sampleProtocols: config.protocols,
     dialog: false,
-    builderOpen: false,
     newProtocolURL: '',
   }),
   computed: {

--- a/src/Components/Builder/Builder.vue
+++ b/src/Components/Builder/Builder.vue
@@ -1,0 +1,14 @@
+<template>
+  <ActivitySetBuilder />
+</template>
+
+<script>
+import Components from 'activity-set-builder';
+
+export default {
+  name: 'Builder',
+  components: {
+    ...Components
+  },
+}
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,11 +1,17 @@
 import Vue from 'vue';
 import Router from 'vue-router';
 import Stepper from '@/Components/Stepper.vue';
+import Builder from '@/Components/Builder/Builder.vue';
 
 Vue.use(Router);
 
 export default new Router({
   routes: [
+    {
+      path: '/build',
+      name: 'Builder',
+      component: Builder,
+    },
     {
       path: '/',
       name: 'Stepper',


### PR DESCRIPTION
When a user clicks 'Launch Builder', the Activity Set Builder opens as a standalone page in a new tab.