### PR TITLE
Applet Upload Confirmation Dialog

### DIFF
--- a/src/Components/Applets/AllApplets.vue
+++ b/src/Components/Applets/AllApplets.vue
@@ -127,9 +127,11 @@ export default {
         protocolUrl: this.newProtocolURL,
         token: this.$store.state.auth.authToken.token,
         apiHost: this.$store.state.backend,
-      }).then(() => {
+      }).then((resp) => {
         this.newProtocolURL = '';
-        this.$emit('refreshAppletList');
+        this.$emit('appletUploadSuccessful', resp);
+      }).catch((e) => {
+        this.$emit('appletUploadError');
       });
     },
     deleteApplet(applet) {

--- a/src/Components/Applets/Applet.vue
+++ b/src/Components/Applets/Applet.vue
@@ -16,7 +16,9 @@
       >
         check
       </v-icon>
-      <v-card-title primary-title>
+      <v-card-title
+        primary-title
+      >
         <h3 class="headline mb-0">
           {{ applet.applet["skos:prefLabel"] }}
         </h3>

--- a/src/Steps/SetApplet.vue
+++ b/src/Steps/SetApplet.vue
@@ -11,7 +11,34 @@
       v-else
       :applets="allApplets"
       @refreshAppletList="getApplets"
+      @appletUploadSuccessful="onAppletUploadSuccessful"
+      @appletUploadError="onAppletUploadError"
     />
+    <v-dialog
+      v-model="dialog"
+    >
+      <v-card>
+        <v-card-title
+          primary-title
+        >
+          Upload Received
+        </v-card-title>
+        <v-card-text>
+          {{ dialogText }}
+        </v-card-text>
+        <v-divider />
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            color="primary"
+            text
+            @click="dialog = false"
+          >
+            Dismiss
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
@@ -36,6 +63,9 @@ export default {
     sampleProtocols: config.protocols,
     error: {},
     status: 'loading',
+    dialog: true,
+    dialogText: '',
+    dialogTextDefault: 'The applet is being created. Please check back in several mintutes to see it. If you have an email address associated with your account, you will receive an email when your applet is ready.',
   }),
   computed: {
     allApplets() {
@@ -78,6 +108,18 @@ export default {
         this.error = e;
         this.status = 'error';
       });
+    },
+    onAppletUploadSuccessful(resp) {
+      if (resp && resp.data && resp.data.message) {
+        this.dialogText = resp.data.message;
+      } else {
+        this.dialogText = dialogTextDefault;
+      }
+      this.dialog = true;
+    },
+    onAppletUploadError() {
+      this.dialogText = 'There was an error uploading your applet. Please try again or report the issue.'
+      this.dialog = true;
     },
     continueAction() {
 

--- a/src/Steps/SetApplet.vue
+++ b/src/Steps/SetApplet.vue
@@ -19,6 +19,7 @@
     >
       <v-card>
         <v-card-title
+          class="headline grey lighten-2"
           primary-title
         >
           Upload Received

--- a/src/Steps/SetApplet.vue
+++ b/src/Steps/SetApplet.vue
@@ -63,7 +63,7 @@ export default {
     sampleProtocols: config.protocols,
     error: {},
     status: 'loading',
-    dialog: true,
+    dialog: false,
     dialogText: '',
     dialogTextDefault: 'The applet is being created. Please check back in several mintutes to see it. If you have an email address associated with your account, you will receive an email when your applet is ready.',
   }),


### PR DESCRIPTION
Confirmation/Error dialog now opens when a user attempts to upload a new applet. If provided, the ```data.message``` text from the api response will be used, otherwise we default to a preconfigured confirmation message. Preview:
![image](https://user-images.githubusercontent.com/31543235/71181000-ea249380-2238-11ea-9d32-838f700240d0.png)
