### PR TITLE
update activity-set-builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1836,9 +1836,9 @@
       "dev": true
     },
     "activity-set-builder": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/activity-set-builder/-/activity-set-builder-0.1.0.tgz",
-      "integrity": "sha512-c1TL5M1OtQiCBEi9dGeP6fZwl3nKzoeutFAjS1DfgQPNCQpmoAhhYu02ZmELvIinaU7B1hbS1HRQpNGHHNGIsQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/activity-set-builder/-/activity-set-builder-0.1.3.tgz",
+      "integrity": "sha512-XYtNTHqF6h2L3yTPDvVHi1EpmAyVZmuhZ2FU52fik3rrT2RuNfXBimd+QD/pMk8O2whZEX0dvFt8Zv8+N9tbpg==",
       "requires": {
         "core-js": "^3.4.3",
         "file-saver": "^2.0.2",
@@ -1848,9 +1848,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.0.tgz",
-          "integrity": "sha512-AHPTNKzyB+YwgDWoSOCaid9PUSEF6781vsfiK8qUz62zRR448/XgK2NtCbpiUGizbep8Lrpt0Du19PpGGZvw3Q=="
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.1.tgz",
+          "integrity": "sha512-186WjSik2iTGfDjfdCZAxv2ormxtKgemjC3SI6PL31qOA0j5LhTDVjHChccoc7brwLvpvLPiMyRlcO88C4l1QQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@ag-grid-community/all-modules": "^22.0.0",
     "@ag-grid-community/vue": "^22.0.0",
-    "activity-set-builder": "0.1.0",
+    "activity-set-builder": "0.1.3",
     "axios": "^0.19.0",
     "babel-loader": "^7.1.5",
     "dayspan-vuetify-2": "^0.2.0",


### PR DESCRIPTION
Update activity-set-builder to version 0.1.3, which includes small bug fixes and support for ```audioImageRecord```, ```audioRecord```, and ```drawing``` widget types.