### PR TITLE
Fix v-card Word Break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] = 2020-1-17
+### Changed
+- Fix word breaks on ```v-card-title```
+- Fix JSON rendering on ```AppletCard``` caused by inconsistent schema
 
 ## [0.1.6] - 2020-01-13
 ## Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/Components/CalendarComponents/CalendarApp.vue
+++ b/src/Components/CalendarComponents/CalendarApp.vue
@@ -798,6 +798,12 @@ export default {
 }
 </script>
 
+<style scoped>
+.v-card__text, .v-card__title {
+  word-break: normal;
+}
+</style>
+
 <style scoped lang="scss">
 
 .ds-app-calendar-toolbar {


### PR DESCRIPTION
- Change word-wrap styling on ```v-card-title```
- Fixes #78 
<img src="https://user-images.githubusercontent.com/31543235/72625508-244f8680-3906-11ea-80fb-5aa592e33d6e.png" alt="drawing" width="400"/>