### PR TITLE
Remove Console Logs from Production Builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.18] = 2020-2-17
+### Changed
+- Add ```babel-plugin-transform-remove-console``` as a ```devDependency```
+- Remove console statements when ```process.env.NODE_ENV === 'production'```
+
 ## [0.1.17] = 2020-2-15
 ### Changed
 - Added and updated ScheduleSpan component

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   presets: [
     '@vue/app'
-  ]
+  ],
+  plugins: ["transform-remove-console"]
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,5 @@ module.exports = {
   presets: [
     '@vue/app'
   ],
-  plugins: ["transform-remove-console"]
+  plugins: process.env.NODE_ENV === 'production' ? ["transform-remove-console"] : []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2357,6 +2357,12 @@
         "resolve": "^1.4.0"
       }
     },
+    "babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
+      "dev": true
+    },
     "babel-register": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.1.15",
+  "version": "0.1.18",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@vue/cli-plugin-eslint": "^3.0.0-rc.10",
     "@vue/cli-service": "^3.0.0-rc.10",
     "babel-core": "^6.26.3",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "eslint": "^6.5.1",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-vue": "^5.2.3",


### PR DESCRIPTION
- Adds ```babel-plugin-transform-remove-console``` as a ```devDependency```
- Removes all console statements when ```process.env.NODE_ENV === 'production'```
- Fixes #108 