### PR TITLE
Update protocol-builder, Restore Travis Build Caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 language: node_js
 node_js:
 - "lts/*"
+cache:	
+  directories:	
+  - node_modules
 branches:
   only:
   - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.23] = 2020-3-9
+### Changed
+- protocol-builder 0.1.12 -> 0.1.13
+- Restored Travis' ```node_modules``` caching
+
 ## [0.1.22] = 2020-3-5
 ### Changed
 - Updated all node dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.1.20",
+  "version": "0.1.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9851,15 +9851,16 @@
       "dev": true
     },
     "protocol-builder": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/protocol-builder/-/protocol-builder-0.1.12.tgz",
-      "integrity": "sha512-iDPmGFQP9AMidpugAQABKEqLML9kr+5VR/StZ9C3Q4JL/zp/6+Sfq1QC+8y1WP5L6TE6Wg4pMoWjBptdxteaXg==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/protocol-builder/-/protocol-builder-0.1.13.tgz",
+      "integrity": "sha512-63lSd+4OV2leJg2HtUq+wMeXms0Pi/C54vIM9+SV+OiwfMxvI8eRt7cNbTG0gShYBBBI8mN9IIhX39MU3ZPKGA==",
       "requires": {
-        "core-js": "^3.4.3",
+        "axios": "^0.19.2",
+        "core-js": "^3.6.4",
         "file-saver": "^2.0.2",
         "jszip": "^3.2.2",
         "vue": "^2.6.10",
-        "vuetify": "^2.1.0"
+        "vuetify": "^2.2.15"
       },
       "dependencies": {
         "core-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-loader": "^7.1.5",
     "dayspan-vuetify-2": "^0.2.0",
     "lodash": "^4.17.15",
-    "protocol-builder": "^0.1.12",
+    "protocol-builder": "^0.1.13",
     "vue": "2.6.10",
     "vue-property-decorator": "^8.4.0",
     "vue-router": "^3.1.6",


### PR DESCRIPTION
- protocol-builder 0.1.12 -> 0.1.13
    - Initial functionality to upload items from GitHub
- restored Travis' ```node_modules``` caching
- First step in #121 