### PR TITLE
Grid Theme + Styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.27] = 2020-3-17
+### Changed
+- Changed ag-grid theme to ```ag-theme-balham```
+- Removed padding from grid container style
+
 ## [0.1.26] = 2020-3-13
 ### Changed
 - Finished individual schedules.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.1.23",
+  "version": "0.1.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,7 +16,7 @@ export default {
 <style lang="scss">
   @import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400');
   @import "../node_modules/@ag-grid-community/all-modules/dist/styles/ag-grid.css";
-  @import "../node_modules/@ag-grid-community/all-modules/dist/styles/ag-theme-bootstrap.css";
+  @import "../node_modules/@ag-grid-community/all-modules/dist/styles/ag-theme-balham.css";
 </style>
 
 <style>

--- a/src/Components/Users/ActiveUserTable.vue
+++ b/src/Components/Users/ActiveUserTable.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <ag-grid-vue
-      class="ag-theme-bootstrap"
+      class="ag-theme-balham"
       :gridOptions="gridOptions"
       :columnDefs="columnDefs"
       :rowSelection="multiSelection"
@@ -14,6 +14,12 @@
     />
   </v-container>
 </template>
+
+<style scoped>
+  .container {
+    padding: 0px;
+  }
+</style>
 
 <script>
 import {AgGridVue} from "@ag-grid-community/vue";

--- a/src/Components/Users/PendingInviteTable.vue
+++ b/src/Components/Users/PendingInviteTable.vue
@@ -11,6 +11,12 @@
   </v-container>
 </template>
 
+<style scoped>
+  .container {
+    padding: 0px;
+  }
+</style>
+
 <script>
 import {AgGridVue} from "@ag-grid-community/vue";
 import {AllCommunityModules} from '@ag-grid-community/all-modules';


### PR DESCRIPTION
- Changed ag-grid theme to ```ag-theme-balham``` because ```ag-theme-bootstrap``` is deprecated
- Removed padding from grid container style to increase grid width