### PR TITLE
Update api endpoint for setSchedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.4] = 2020-07-28
+### Changed
+- Fix duplicated event card
+
 ## [0.2.3] = 2020-07-20
 ### Changed
 - Update cache of applets

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/Components/Utils/api/api.vue
+++ b/src/Components/Utils/api/api.vue
@@ -29,7 +29,7 @@ const resetPassword = ({apiHost, body}) => axios({
 
 const setSchedule = ({ apiHost, token, id, data }) => axios({
   method: 'put',
-  url: `${apiHost}/applet/${id}/schedule?rewrite=false`,
+  url: `${apiHost}/applet/${id}/schedule`,
   headers: {
     'Girder-Token': token,
   },


### PR DESCRIPTION
Update API endpoint to fix duplicated event card
Resolve [#271](https://github.com/ChildMindInstitute/mindlogger-admin/issues/271)