### PR TITLE
Fix dashboard time range label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] = 2020-09-08
+### Changed
+- Fixed styles and format for the time range label in the dashboard
+
 ## [0.3.1] = 2020-08-26
 ### Changed
 - Updated applet-schema-buider ```0.2.5``` to ```0.2.6```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/Components/Charts/TokenChart.vue
+++ b/src/Components/Charts/TokenChart.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="TokenChart" ref="container" >
-    {{ focusExtent }}
+    <div class="time-range">
+      Showing data from
+      <span class="date">{{ focusExtent[0].toDateString() }}</span>
+      to
+      <span class="date">{{ focusExtent[1].toDateString() }}</span>
+    </div>
 
     <svg :id="plotId" >
       <defs>
@@ -55,11 +60,25 @@
   display: inline-block;
   position: relative;
   width: 100%;
-  height: 500px;
+  height: 550px;
   vertical-align: top;
-  margin: 2rem 1rem;
+  margin: 0 1rem 2rem 1rem;
   margin-bottom: 0;
   user-select: none;
+}
+
+.TokenChart .time-range {
+  margin-bottom: 2rem;
+  margin-left: -0.8rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #777;
+  text-transform: uppercase;
+}
+
+.TokenChart .time-range .date {
+  margin: 0 0.3rem;
+  color: #1976D2;
 }
 
 .TokenChart .chart {


### PR DESCRIPTION
The dashboard contained debugging code that displayed a plain array with the start and end date for the selected time window.

![image](https://user-images.githubusercontent.com/1501339/92545605-e69dc600-f226-11ea-99d3-8e0baf6658b8.png)

The date was properly formatted and styled as shown in the following screenshot:

![image](https://user-images.githubusercontent.com/1501339/92545663-ff0de080-f226-11ea-94aa-df97b7d8ef8f.png)

This closes issue #330 