### PR TITLE
Hide "Remove User" button #337

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] = 2020-09-13
+### Changed
+- Hide the "Remove User" option for users who are not managers
 
 ## [0.3.4] = 2020-09-06
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.2",
+  "version": "0.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/Components/Users/ActiveUserTable.vue
+++ b/src/Components/Users/ActiveUserTable.vue
@@ -147,6 +147,9 @@ export default {
     isManager() { 
       return this.$store.state.currentAccount.applets['manager'];
     },
+    isCoordinator() { 
+      return this.$store.state.currentAccount.applets['coordinator'];
+    },
     computedItems() {
       return this.userRoleData.map((item) => {
         return {
@@ -157,10 +160,9 @@ export default {
     },
   },
   beforeMount() {
+    const { isManager, isCoordinator } = this;
     this.gridOptions = {};
-    const isManager = this.$store.state.currentAccount.applets["manager"]
-      ? true
-      : false;
+
     if (isManager) {
       this.userData = this.users.map((user) => {
         let roles = [];
@@ -219,7 +221,7 @@ export default {
       },
     ];
 
-    if (isManager) {
+    if (isManager || isCoordinator) {
       this.columnDefs.push({
         headerName: "",
         field: "athelete",
@@ -228,6 +230,7 @@ export default {
         cellRenderer: "btnCellRenderer",
         cellRendererParams: {
           clicked: this.onClickedHander,
+          isManager: isManager,
         },
       });
     }

--- a/src/Components/Users/ActiveUserTable.vue
+++ b/src/Components/Users/ActiveUserTable.vue
@@ -175,6 +175,9 @@ export default {
     };
   },
   computed: {
+    isManager() { 
+      return this.$store.state.currentAccount.applets['manager'];
+    },
     computedItems() {
       return this.userRoleData.map(item => {
         return {
@@ -243,7 +246,10 @@ export default {
         resizable: true,
         cellStyle: {justifyContent: 'center'}
       },
-      {
+    ];
+
+    if (isManager) {
+      this.columnDefs.push({
         headerName: '',
         field: 'athelete',
         maxWidth: 200,
@@ -252,8 +258,9 @@ export default {
         cellRendererParams: {
           clicked: this.onClickedHander
         },
-      },
-    ];
+      });
+    }
+
     this.frameworkComponents = {
       btnCellRenderer: BtnCellRenderer
     };

--- a/src/Components/Users/BtnCellRenderer.vue
+++ b/src/Components/Users/BtnCellRenderer.vue
@@ -46,8 +46,10 @@
         >
           <v-list-item-title> Remove user </v-list-item-title>
         </v-list-item>
+
         <v-list-item 
           link
+          v-if="params.isManager"
           @click="btnDeletedHandler('deleteData')"
         >
           <v-list-item-title> Remove user & data </v-list-item-title>


### PR DESCRIPTION
The "Remove user" option was being shown for every user type. This PR changes makes sure that only managers will see it.

Issue #337

Testing this PR:
1. Log into the admin panel using the reviewer account
2. Go to the "Manager Users" page
3. Make sure that you are not able to remove users