### PR TITLE
Add support for string token values in dashboard #345

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7] = 2020-09-14
+
+### Changed
+- Add support for strings as token values in the dashboard
+
 ## [0.3.5] = 2020-09-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.4",
+  "version": "0.3.7",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/models/Item.js
+++ b/src/models/Item.js
@@ -71,10 +71,30 @@ export default class Item {
     return this.responseOptions.find(choice => choice.value === value);
   }
 
+  getChoiceByName(name) {
+    return this.responseOptions.find(choice => choice.name.en === name);
+  }
+
+  getChoice(str) {
+    const numericValue = +str;
+
+    return Number.isNaN(numericValue)
+      ? this.getChoiceByName(str)
+      : this.getChoiceByValue(numericValue);
+  }
+
+
   setResponses(responses) {
-      this.responses = responses.map(response => response.value.reduce(
-        (obj, value) => {
-          const choice =  this.getChoiceByValue(value);
+    this.responses = responses.map(response => {
+      if (!Array.isArray(response.value)) {
+        // Ensure that it is an array.
+        response.value = [response.value];
+      }
+
+      return response.value.reduce(
+        (obj, tokenValue) => {
+          const choice =  this.getChoice(tokenValue);
+          const { value, name } = choice;
 
           return {
             ...obj,
@@ -82,7 +102,7 @@ export default class Item {
             positive: value > 0 ? obj.positive + value : obj.positive,
             negative: value < 0 ? obj.negative + value : obj.negative,
             userActivity: true,
-            [choice.name.en]: value,
+            [name.en]: value,
           };
         },
         {
@@ -92,6 +112,7 @@ export default class Item {
           negative: 0,
           userActivity: false,
         },
-      ));
+      );
+    });
   }
 }


### PR DESCRIPTION
Add support for string token values in the token logger dashboard.

Issue #345 

Testing this PR:
1. Create a new user response in a token applet using the latest mobile app version
2. Log into the admin panel using the owner or reviewer account
3. Check whether the dashboard loads correctly or not