### PR TITLE
Fix timezone in dashboard charts #347

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] = 2020-09-14
+
+### Changed
+
+- Fix timezone handling in dashboard
+
+
 ## [0.3.5] = 2020-09-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.4",
+  "version": "0.3.8",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/Components/Charts/TokenChart.vue
+++ b/src/Components/Charts/TokenChart.vue
@@ -2,9 +2,9 @@
   <div class="TokenChart" ref="container" >
     <div class="time-range">
       Showing data from
-      <span class="date">{{ focusExtent[0].toDateString() }}</span>
+      <span class="date">{{ fromDate }}</span>
       to
-      <span class="date">{{ focusExtent[1].toDateString() }}</span>
+      <span class="date">{{ toDate }}</span>
     </div>
 
     <svg :id="plotId" >
@@ -136,6 +136,7 @@
 
 <script>
 import * as d3 from 'd3';
+import * as moment from 'moment';
 
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
@@ -143,7 +144,7 @@ const NOW = new Date();
 const TODAY = new Date(Date.UTC(
   NOW.getFullYear(),
   NOW.getMonth(),
-  NOW.getDate() + 1,
+  NOW.getDate(),
   0,
   0,
   0,
@@ -194,6 +195,15 @@ export default {
       bottom: 0,
     },
   }),
+
+  computed: {
+    fromDate() {
+      return moment.utc(this.focusExtent[0]).format('ddd, D MMM YYYY');
+    },
+    toDate() {
+      return moment.utc(this.focusExtent[1]).format('ddd, D MMM YYYY');
+    },
+  },
 
   /**
    * Method to be executed after the component has been mounted.
@@ -404,19 +414,13 @@ export default {
         .scale(this.x)
         .ticks(d3.utcDay)
         .tickSize(this.focusHeight)
-        .tickFormat(d => d.toLocaleDateString(
-          'default',
-          { day: 'numeric', month: 'short' },
-        ));
+        .tickFormat(d => moment.utc(d).format('MMM D'));
       const contextXAxis = d3
         .axisBottom()
         .scale(this.contextX)
         .ticks(15)
         .tickSize(this.contextHeight)
-        .tickFormat(d => d.toLocaleDateString(
-          'default',
-          { day: 'numeric', month: 'numeric' },
-        ));
+        .tickFormat(d => moment.utc(d).format('M/D'));
       const yAxis = d3
         .axisLeft()
         .scale(this.y)


### PR DESCRIPTION
Dates were being displayed incorrectly in the dashboard due to timezone. This was corrected in this PR.

Fixes #347

Testing this:
1. Create a new user response using the mobile app.
2. Log into the admin panel using the owner or reviewer account
3. Make sure that the new response is shown with today's date