### PR TITLE
Fix reviewer access to users page #349

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.10] = 2020-09-16
+### Changed
+- Allow reviewers to access the users page 
+
 ## [0.3.9] = 2020-09-10
 ### Changed
 - Fixed dashboard chart showing decimal values in y-axis labels

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.8",
+  "version": "0.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/Components/Applets/AppletCard.vue
+++ b/src/Components/Applets/AppletCard.vue
@@ -91,7 +91,10 @@
               </template>
               <v-list>
                 <v-list-item
-                  :disabled="!applet.roles.includes('coordinator')"
+                  :disabled="
+                    !applet.roles.includes('coordinator') &&
+                    !applet.roles.includes('reviewer')
+                  "
                   @click="onViewUsers"
                 >
                   <v-list-item-title>View Users</v-list-item-title>


### PR DESCRIPTION
For some reason, reviewers were unable to access the users page. This PR fixes this issue.

Fixes #349 

**Testing this PR:**
1. Log into the app as a reviewer.
2. On the applet card, click on "Select"
3. Make sure that the "View Users" option is enabled and click on it
4. Pay attention to the result

**Expected result:**
The app should take you to the users page. It should show the list of users that the reviewer has access to.