### PR TITLE
Fix token chart legend #344

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.10] = 2020-09-17
+### Changed
+- Fixed chart legend overflowing container
+
 ## [0.3.9] = 2020-09-10
 ### Changed
 - Fixed dashboard chart showing decimal values in y-axis labels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.10] = 2020-09-16
 ### Changed
 - Allow reviewers to access the users page 
->>>>>>> develop
 
 ## [0.3.9] = 2020-09-10
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.8",
+  "version": "0.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/Components/Charts/TokenChart.vue
+++ b/src/Components/Charts/TokenChart.vue
@@ -1,5 +1,21 @@
 <template>
   <div class="TokenChart" ref="container" >
+    <div class="legend">
+      <div 
+        class="legend-item" 
+        v-for="feature in features"
+        :key="feature.name.en"
+      >
+        <div 
+          class="color-box"
+          :style="{ background: feature.color }">
+        </div>
+        <div class="label">
+          {{ feature.name.en }}
+        </div>
+      </div>
+    </div>
+
     <div class="time-range">
       Showing data from
       <span class="date">{{ fromDate }}</span>
@@ -31,7 +47,6 @@
         clip-path="url(#clip)"
       />
 
-      <g class="legend-container"/>
       <g
         class="tooltip"
         style="display: none"
@@ -60,7 +75,6 @@
   display: inline-block;
   position: relative;
   width: 100%;
-  height: 550px;
   vertical-align: top;
   margin: 0 1rem 2rem 1rem;
   margin-bottom: 0;
@@ -81,6 +95,29 @@
   color: #1976D2;
 }
 
+.TokenChart .legend {
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  margin: 1rem 0;
+}
+
+.TokenChart .legend .legend-item {
+  display: flex;
+  align-items: center;
+  min-width: 45%;
+  margin-right: 30px;
+  margin-bottom: 12px;
+  flex: 1 1 0px;
+}
+
+.TokenChart .legend .legend-item .color-box {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  margin-right: 0.5rem;
+}
+
 .TokenChart .chart {
   overflow: hidden;
 }
@@ -88,6 +125,7 @@
 .TokenChart > svg {
   display: block;
   overflow: visible;
+  height: 500px;
 }
 
 .TokenChart > svg .selection {
@@ -186,7 +224,7 @@ export default {
     },
     focusMargin: {
       top: 40,
-      right: 200,
+      right: 50,
       bottom: 130,
       left: 30,
     },
@@ -382,7 +420,6 @@ export default {
 
       this.resize();
       this.drawAxes();
-      this.drawLegend();
       this.drawBrush();
       this.drawFocusChart();
       this.drawContextChart();
@@ -492,47 +529,6 @@ export default {
         .attr('x2', this.width + focusBarWidth)
         .attr('y1', this.contextY(0))
         .attr('y2', this.contextY(0));
-    },
-
-    /**
-     * Draws the legend for the chart.
-     *
-     * @return {void}
-     */
-    drawLegend() {
-      const { svg } = this;
-
-      svg
-        .selectAll('.legend')
-        .remove();
-
-      const legend = svg
-        .select('.legend-container')
-        .selectAll('.legend')
-        .data(this.features)
-        .enter()
-        .append('g')
-        .attr('class', 'legend')
-        .attr('transform', (d, i) => `translate(30, ${i*28})`);
-
-      // Render the color square.
-      legend
-        .append('rect')
-        .attr('y', this.focusMargin.top)
-        .attr('x', this.width + this.focusMargin.left + 10)
-        .attr('width', 18)
-        .attr('height', 18)
-        .style('fill', f => f.color);
-
-      // Render the legend text.
-      legend
-        .append('text')
-        .attr('x', this.width + this.focusMargin.left + 40)
-        .attr('y', this.focusMargin.top + 9)
-        .attr('dy', '.35em')
-        .attr('text-anchor', 'start')
-        .attr('font-size', '12px')
-        .text(f => f.name.en);
     },
 
     /**

--- a/src/models/Item.js
+++ b/src/models/Item.js
@@ -56,6 +56,7 @@ export default class Item {
       '#BEE0CC',
       '#223B89',
       '#316BA7',
+      '#1976D2',
     ];
 
     return itemListElement.map((choice, index) => ({

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,9 @@
 module.exports = {
-  "transpileDependencies": [
+  devServer: {
+    disableHostCheck: true,
+    port: 8082,
+  },
+  transpileDependencies: [
     "vuetify"
   ]
 };


### PR DESCRIPTION
The legend of the token chart (in the dashboard) was overflowing the container. This PR fixes that.

**Testing this PR:**
1. Log into the app using the owner account
2. In the TokenLogger_school applet click on **Select > View Users**
3. Select any user from the **Active Users** list and click the dashboard icon on the bottom.
4. Make sure that the legend of the chart doesn't overflow its container and that the styles are correct.

It should look something like this:
![image](https://user-images.githubusercontent.com/1501339/93474341-97623000-f8cd-11ea-9a9f-e4ce1c479816.png)
