### PR TITLE
0.3.21 - Bugfix/applet create #387

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.21] = 2020-10-01
+### Changed
+- update encryption info for applets created by builder
+- update dialog text after creating new applet
+
 ## [0.3.19] = 2020-09-30
 ### Changed
 - Fixed duplicated definition of userData

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.18",
+  "version": "0.3.21",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/Components/Builder/Builder.vue
+++ b/src/Components/Builder/Builder.vue
@@ -90,12 +90,22 @@ export default {
       this.appletPasswordDialog = true;
     },
     addNewApplet(appletPassword) {
-      const protocol = new FormData();
-      protocol.set("protocol", JSON.stringify(this.newApplet || {}));
+      const form = new FormData();
+      form.set("protocol", JSON.stringify(this.newApplet || {}));
+
+      const encryptionInfo = encryption.getAppletEncryptionInfo({
+        appletPassword: appletPassword,
+        accountId: this.$store.state.currentAccount.accountId
+      });
+      form.set('encryption', JSON.stringify({
+        appletPublicKey: Array.from(encryptionInfo.getPublicKey()),
+        appletPrime: Array.from(encryptionInfo.getPrime()),
+        base: Array.from(encryptionInfo.getGenerator())
+      }));
 
       api
         .createApplet({
-          data: protocol,
+          data: form,
           email: this.$store.state.userEmail,
           token: this.$store.state.auth.authToken.token,
           apiHost: this.$store.state.backend,
@@ -151,8 +161,8 @@ export default {
         this.componentKey = this.componentKey + 1;
       });
     },
-    onUploadSucess() {
-        this.dialogText = 'Your applet is successfully updated';
+    onUploadSucess(msg) {
+        this.dialogText = msg || 'Your applet is successfully updated';
         this.dialogTitle = 'Upload Received';
         this.dialog = true;
     },


### PR DESCRIPTION
# Resolves [387](https://app.zenhub.com/workspaces/mindlogger-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-admin/387)

# update response message for applet create using builder
# insert encryption info for applets created by builder
