### PR TITLE
0.3.26 - Fix cumulative tokens #886

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.26] = 2020-10-07
+### Changed
+- Make tokens cumulative
+
 ## [0.3.25] = 2020-10-06
 ### Changed
 - Fix merge conflict

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/Components/Charts/TokenChart.vue
+++ b/src/Components/Charts/TokenChart.vue
@@ -461,15 +461,32 @@ export default {
       let cummulative;
       let value;
 
+      // Compute the maximum value of one user response.
       for (let i = 0; i < this.features.length; i++) {
         value = this.features[i].value;
-
 
         if (value < 0) {
           this.divergingExtent.min += value;
         } else {
           this.divergingExtent.max += value;
         }
+      }
+
+      let positive;
+      let negative;
+
+      // Find the maximum value for cumulative user responses.
+      for (let i = 0; i < this.data.length; i++) {
+        positive = this.data[i].positive;
+        negative = this.data[i].negative;
+
+        if (positive > this.divergingExtent.max) {
+          this.divergingExtent.max = positive;
+        }
+
+        if (negative < this.divergingExtent.min) {
+          this.divergingExtent.min = negative;
+        } 
       }
 
       if (this.divergingExtent.max % 2) {

--- a/src/models/Item.js
+++ b/src/models/Item.js
@@ -103,7 +103,7 @@ export default class Item {
             positive: value > 0 ? obj.positive + value : obj.positive,
             negative: value < 0 ? obj.negative + value : obj.negative,
             userActivity: true,
-            [name.en]: value,
+            [name.en]: (obj[name.en] || 0) + value,
           };
         },
         {


### PR DESCRIPTION
Up to now, only the latest daily user response for token logger was being taken into account. However, all user responses need to be taken into account. Every time the user takes an assessment the tokens need to accumulate.

[Issue #886](https://app.zenhub.com/workspaces/mindlogger-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-backend/886)

**Depends on:**
[Backend PR 887](https://github.com/ChildMindInstitute/mindlogger-backend/pull/887)


**How to test this PR:**
1. Go to the dashboard for a token logger applet.
2. See what are the tokens for today.
3. Take the assessment multiple times.
4. Check that the token value in the dashboard keeps increasing every time you take the assessment.

![image](https://user-images.githubusercontent.com/1501339/95323764-0ef40100-0875-11eb-9747-15eb909e1765.png)
