### PR TITLE
v0.3.26 - Fix token data encryption #389

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.27] = 2020-10-11
+### Changed
+- Fix encryption code in Applet#replaceItemValues method 
+
 ## [0.3.26] = 2020-10-07
 ### Changed
 - Make tokens cumulative

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/models/Applet.js
+++ b/src/models/Applet.js
@@ -116,8 +116,14 @@ export default class Applet {
       const responses = data.responses[itemId];
 
       for (let response of responses) {
-        if (response.value && response.value.ptr !== undefined && response.value.src !== undefined) {
-          response.value = data.dataSources[response.value.src].data[response.value.ptr];
+        if (
+          Array.isArray(response.value) && 
+          response.value.length > 0  && 
+          response.value[0].ptr !== undefined && 
+          response.value[0].src !== undefined
+        ) 
+        {
+          response.value = data.dataSources[response.value[0].src].data[response.value[0].ptr];
         }
       }
     }


### PR DESCRIPTION
The dashboard crashed for applets containing responses created by the latest version of the backend. The admin panel code tried to access the user data in an incorrect way. This PR fixes that.

Issue #389 

**Testing this PR**
1. Create user responses for a token logger applet
2. Go to the dashboard for that applet
3. See the result

**Expected result**
The dashboard doesn't crash and it shows the data.