### PR TITLE
update naming strategy for applet duplication

### DIFF
--- a/src/Components/Applets/AllApplets.vue
+++ b/src/Components/Applets/AllApplets.vue
@@ -285,9 +285,17 @@ export default {
         });
     },
     duplicateApplet(applet) {
-      this.appletDuplicateDialog.visibility = true;
-      this.appletDuplicateDialog.applet = applet;
-      this.$refs.appletNameDialog.appletName = `duplicate of ${applet.applet['http://www.w3.org/2004/02/skos/core#prefLabel'][0]['@value']}`;
+      api
+        .validateAppletName({
+          apiHost: this.$store.state.backend,
+          token: this.$store.state.auth.authToken.token,
+          name: `${applet.applet['http://www.w3.org/2004/02/skos/core#prefLabel'][0]['@value']} (1)`
+        })
+        .then(resp => {
+          this.appletDuplicateDialog.visibility = true;
+          this.appletDuplicateDialog.applet = applet;
+          this.$refs.appletNameDialog.appletName = resp.data;
+        })
     },
 
     onSetAppletDuplicateName(appletName) {

--- a/src/Components/Utils/api/api.vue
+++ b/src/Components/Utils/api/api.vue
@@ -358,6 +358,16 @@ const getProtocolData = ({ apiHost, token, appletId, versions }) => axios({
   params: { versions: JSON.stringify(versions) },
 })
 
+
+const validateAppletName = ({ apiHost, token, name }) => axios({
+  method: 'get',
+  url: `${apiHost}/applet/validateName`,
+  headers: {
+    'Girder-Token': token
+  },
+  params: { name }
+});
+
 export default {
   signIn,
   signUp,
@@ -393,5 +403,6 @@ export default {
   getAppletVersions,
   getProtocolData,
   prepareApplet,
+  validateAppletName,
 }
 </script>


### PR DESCRIPTION
# Resolves [439](https://app.zenhub.com/workspaces/mindlogger-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-admin/439)

# update naming for duplicated applet
# Compatible with [backend PR](https://github.com/ChildMindInstitute/mindlogger-backend/pull/905)
