### PR TITLE
0.3.34 - Bugfix/#892

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.34] = 2020-10-29
+- show reviewer dashboard as user's timezone
+
 ## [0.3.33] = 2020-10-23
 - insert option to show/hide version bars
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/Steps/TokenLoggerDashboard.vue
+++ b/src/Steps/TokenLoggerDashboard.vue
@@ -42,6 +42,7 @@
             :features="item.responseOptions"
             :versionsByDate="item.dateToVersions"
             :versions="applet.versions"
+            :timezone="item.timezoneStr"
           />
         </v-card>
       </div>

--- a/src/models/Applet.js
+++ b/src/models/Applet.js
@@ -140,6 +140,10 @@ export default class Applet {
       let merged = [], last = null;
 
       data.responses[itemId].forEach(resp => {
+        this.items[itemId].timezoneStr = resp.date.substr(-6);
+
+        resp.date = resp.date.substr(0, 10);
+
         if (last && resp.date == last.date && resp.version == last.version) {
           last.value.push(...resp.value);
         } else {
@@ -177,15 +181,7 @@ export default class Applet {
       params: { retrieveDate: true }
     });
 
-    this.versions = data.map(d => {
-      const updated = new Date(d.updated);
-      const formatted = moment(updated).format("YYYY-MM-DD");
-      return { 
-        version: d.version, 
-        formatted,
-        updated: moment(formatted).set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
-      };
-    });
+    this.versions = data;
   }
 
   insertInitialVersion() {

--- a/src/models/Item.js
+++ b/src/models/Item.js
@@ -51,6 +51,7 @@ export default class Item {
     this.schemaVersion = data['schema:schemaVersion'] && i18n.arrayToObject(data['schema:schemaVersion']);
     this.responseOptions = this.parseResponseOptions(data[ReproLib.responseOptions]);
     this.responses = [];
+    this.timezoneStr = '+00:00';
     this.maxValue = data[ReproLib.responseOptions] && 'schema:maxValue' in data[ReproLib.responseOptions][0]
       ? data[ReproLib.responseOptions][0]['schema:maxValue'][0]['@value']
       : 0;


### PR DESCRIPTION
# Resolves [892](https://app.zenhub.com/workspaces/mindlogger-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-backend/892)

# show reviewer dashboard as user's timezone
# compatible with [backend PR](https://github.com/ChildMindInstitute/mindlogger-backend/pull/913)
