### PR TITLE
0.3.35 - Bugfix/#439 #461

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.35] = 2020-10-29
+- fix applet naming for duplicated applets
+
 ## [0.3.33] = 2020-10-23
 - insert option to show/hide version bars
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.33",
+  "version": "0.3.35",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/Components/Applets/AllApplets.vue
+++ b/src/Components/Applets/AllApplets.vue
@@ -280,13 +280,17 @@ export default {
         });
     },
     duplicateApplet(applet) {
-      this.appletDuplicateDialog.visibility = true;
-      this.appletDuplicateDialog.applet = applet;
-      this.$refs.appletNameDialog.appletName = `duplicate of ${
-        applet.applet["http://www.w3.org/2004/02/skos/core#prefLabel"][0][
-          "@value"
-        ]
-      }`;
+      api
+        .validateAppletName({
+          apiHost: this.$store.state.backend,
+          token: this.$store.state.auth.authToken.token,
+          name: `${applet.applet['http://www.w3.org/2004/02/skos/core#prefLabel'][0]['@value']} (1)`
+        })
+        .then(resp => {
+          this.appletDuplicateDialog.visibility = true;
+          this.appletDuplicateDialog.applet = applet;
+          this.$refs.appletNameDialog.appletName = resp.data;
+        })
     },
 
     onSetAppletDuplicateName(appletName) {

--- a/src/Components/Users/CreateInvitationForm.vue
+++ b/src/Components/Users/CreateInvitationForm.vue
@@ -44,7 +44,7 @@
           <v-col v-if="params.role === 'user'" cols="12" sm="6" md="4">
             <v-text-field
               v-model="params.profile.mrn"
-              :label="$t('createInvitation')"
+              :label="$t('institutionalID')"
             />
           </v-col>
           <v-col v-else cols="12" sm="6" md="4">


### PR DESCRIPTION
# Resolves [439](https://app.zenhub.com/workspaces/mindlogger-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-admin/439), [461](https://app.zenhub.com/workspaces/mindlogger-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-admin/461)

# fix naming for duplicated applet
