### PR TITLE
0.3.36 - Allow language to be defined in the URL #87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.37] = 2020-10-29
+- allow the language to be defined in the URL
+
 ## [0.3.33] = 2020-10-23
 - insert option to show/hide version bars
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindlogger-admin",
-  "version": "0.3.33",
+  "version": "0.3.37",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode local",

--- a/src/App.vue
+++ b/src/App.vue
@@ -65,6 +65,10 @@ import _ from 'lodash';
 export default {
   name: 'App',
   store,
+
+  /**
+   * Define here all computed properties.
+   */
   computed: {
     isLoggedIn() {
       return !_.isEmpty(this.$store.state.auth);
@@ -88,9 +92,20 @@ export default {
       return accounts;
     },
   },
+
+  /**
+   * This method gets executed when the VNode has been created.
+   *
+   * @returns {void}
+   */
   created() {
+    this.$store.commit('setCurrentLanguage', this.$route.query.lang || 'en_US');
     this.$store.commit('setBackend', null);
   },
+
+  /**
+   * Define here all methods that will be available in the scope of the template.
+   */
   methods: {
     logout() {
       this.$store.commit('resetState');

--- a/src/Components/Authentication/LoginForm.vue
+++ b/src/Components/Authentication/LoginForm.vue
@@ -110,6 +110,10 @@ export default {
     },
   },
 
+  created() {
+    this.currentLanguage = this.$store.state.currentLanguage;
+  },
+
   methods: {
     onLanguageChange() {
       this.$i18n.locale = this.currentLanguage;

--- a/src/State/state.js
+++ b/src/State/state.js
@@ -211,7 +211,12 @@ const mutations = {
   },
 };
 
-const stateCopy = (({ allApplets, ...o }) => o)(state);
+const stateCopy = (({ 
+  // Excluded properties.
+  allApplets, 
+  currentLanguage,
+  ...o
+}) => o)(state);
 const stateToPersist = Object.keys(stateCopy);
 
 export const storeConfig = {

--- a/src/plugins/language.js
+++ b/src/plugins/language.js
@@ -1,34 +1,46 @@
+// Third-party libraries.
 import Vue from 'vue';
 import VueI18n from 'vue-i18n';
-import store from '../State/state';
 import _ from 'lodash';
 
+// Local.
+import store from '../State/state';
+
+// Translations.
 import en_US from './locales/en_US';
 import fr_FR from './locales/fr_FR';
 
+
 Vue.use(VueI18n);
 
-// detect browser language
-const browserLanguage = (() => {
+/**
+ * Detects the browser langauge.
+ *
+ * @returns {string} the current browser language.
+ */
+const getBrowserLanguage = () => {
   const language = navigator.language || navigator.userLanguage;
 
-  if (
-    ['fr', 'fr-BE', 'fr-CA', 'fr-CH', 'fr-FR', 'fr-LU', 'fr-MC'].includes(
-      language
-    )
-  ) {
+  if (language.startsWith('fr')) { 
     return 'fr_FR';
   }
 
   return 'en_US';
-})();
+};
 
-// check if a language setting is stored already
-const locale = _.get(store, 'state.currentLanguage', browserLanguage);
+// Detect language in the URL.
+const queryString = window.location.hash.split('?').pop();
+const urlParams = new URLSearchParams(queryString);
+const urlLanguage = urlParams.get('lang');
 
-// new instance
+
+// Initialize the extended Vue instance. 
 export default new VueI18n({
-  locale,
+  locale: (
+    urlLanguage || 
+    _.get(store, 'state.currentLanguage') ||
+    getBrowserLanguage()
+  ),
   messages: {
     en_US,
     fr_FR,


### PR DESCRIPTION
Allows the language to be defined in the URL.

Fix [web-vue#87](https://github.com/ChildMindInstitute/mindlogger-web-vue-OLD/issues/87)

**Testing this PR**
1. Open a new tab (note that this step is important)
2. Enter the URL for the web app and add `?lang=fr_FR` at the end
3. Navigate to that URL
4. Pay attention to the result
5. Repeat this process with `?lang=en_US`

**Expected result**
The app should be in the selected language.