### PR TITLE
[Redesign]All roles are assigned to the user after accepting an invitation to be a manager of an applet on the "MANAGERS" tab 

### DIFF
--- a/src/Components/Users/EmployerList.vue
+++ b/src/Components/Users/EmployerList.vue
@@ -200,12 +200,14 @@ export default {
       for (let applet of this.accountApplets) {
         appletRoles[applet.id] = applet.roles;
       }
-
       for (let i = 0; i < this.employers.length; i++) {
         const employer = this.employers[i];
         const data = Object.values(employer)[0];
         let editable = [];
-
+        if (!data.roles.includes(this.role)) // need to filter based on the selected user role. It might need to be adjusted on back end.
+        {
+          continue;
+        }
         for (let appletId in employer) {
           let profile = employer[appletId];
 
@@ -232,7 +234,6 @@ export default {
           formatted.push(formattedInfo);
         }
       }
-
       return formatted;
     },
   },


### PR DESCRIPTION
**Resolve** #559 
Just for notification,  @jj105  I think this issue need to be fixed on back end side, specifically `${apiHost}/account/users` always return all the users even though the request data sent to get the users based on selected role.
I made front end to filter the users based on selected role tab as well, but I guess it need to be done on back end first.