### PR TITLE
Hide category, sub-category when sharing an applet with library

### DIFF
--- a/src/Components/Utils/dialogs/ShareAppletWithLibraryDialog.vue
+++ b/src/Components/Utils/dialogs/ShareAppletWithLibraryDialog.vue
@@ -88,7 +88,7 @@
           <v-form v-model="valid">
             <v-container fluid class="d-flex py-0">
               <v-container fluid class="mr-5 pa-0">
-                <v-row align="center">
+                <v-row v-if="false" align="center">
                   <v-col md="3" class="text-right"> Category: </v-col>
                   <v-col md="9">
                     <template v-if="isEditing">
@@ -109,7 +109,7 @@
                     </template>
                   </v-col>
                 </v-row>
-                <v-row align="center">
+                <v-row v-if="false" align="center">
                   <v-col md="3" class="text-right"> Sub-Category: </v-col>
                   <v-col md="9">
                     <template v-if="isEditing">
@@ -329,12 +329,11 @@ export default {
         const { url } = await this.publishAppletToLibrary(this.appletId, true);
         this.appletUrl = url;
       }
-      await this.updateAppletSearchTerms(
-        this.appletId,
-        this.categoryName,
-        this.subCategoryName,
-        JSON.stringify(this.keywords)
-      );
+      await this.updateAppletSearchTerms(this.appletId, {
+        // category: this.categoryName,
+        // subCategory: this.subCategoryName,
+        keywords: JSON.stringify(this.keywords),
+      });
       this.isPublished = true;
       this.isEditing = false;
     },

--- a/src/Components/Utils/mixins/AppletLibraryMixin.js
+++ b/src/Components/Utils/mixins/AppletLibraryMixin.js
@@ -34,12 +34,8 @@ export const AppletLibraryMixin = {
           return resp.data;
         })
     },
-    updateAppletSearchTerms(appletId, category, subCategory, keywords) {
-      return api.updateAppletSearchTerms(this.apiHost, this.token, appletId, {
-        category,
-        subCategory,
-        keywords
-      })
+    updateAppletSearchTerms(appletId, searchTerms) {
+      return api.updateAppletSearchTerms(this.apiHost, this.token, appletId, searchTerms)
         .then(resp => {
           return resp.data;
         })


### PR DESCRIPTION
# Resolves [#40](https://app.zenhub.com/workspaces/mindlogger-webapp-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-applet-library/40)