### PR TITLE
fix: remove hash from web app join links

### DIFF
--- a/src/Components/Users/InviteLink.vue
+++ b/src/Components/Users/InviteLink.vue
@@ -106,7 +106,7 @@ export default {
     populateAppletInviteLink(invite) {
       this.inviteLink = invite && invite.data && invite.data.inviteId ? {
         ...invite.data,
-        url: `${process.env.VUE_APP_WEB_URI}/#/join/${invite.data.inviteId}`
+        url: `${process.env.VUE_APP_WEB_URI}/join/${invite.data.inviteId}`
       } : undefined;
     },
 

--- a/src/Components/Users/PublicLink.vue
+++ b/src/Components/Users/PublicLink.vue
@@ -161,7 +161,7 @@ export default {
         return null;
       }
 
-      let url = `${process.env.VUE_APP_WEB_URI}/#/join/${invite.data.inviteId}`;
+      let url = `${process.env.VUE_APP_WEB_URI}/join/${invite.data.inviteId}`;
 
       if (invite.data.requireLogin === false) {
         url = `${process.env.VUE_APP_WEB_URI}/applet/public/${invite.data.inviteId}`;


### PR DESCRIPTION
### Actual Behavior

The Minlogger [web app](https://github.com/ChildMindInstitute/mindlogger-web) excepts URL provided without **#**.

This admin app has been recently updated to remove these for nominated applets URLs but, has not been updated to remove these hash from the generated web app `join` routes.

### Expected Behavior

Web app URLs should not contains hash.

### Side notes

This solve all QA "issues" reported in backend task [#1074](https://github.com/ChildMindInstitute/mindlogger-backend/issues/1074#issuecomment-884797770).

### Credits

This pull request is part of the "Citizen Science Logger" project and, provided by the [ETH Library Lab](https://www.librarylab.ethz.ch/).